### PR TITLE
(minor) remove redundant semicolon

### DIFF
--- a/FastNoise.h
+++ b/FastNoise.h
@@ -45,7 +45,7 @@ typedef float FN_DECIMAL;
 class FastNoise
 {
 public:
-	explicit FastNoise(int seed = 1337) { SetSeed(seed); CalculateFractalBounding(); };
+	explicit FastNoise(int seed = 1337) { SetSeed(seed); CalculateFractalBounding(); }
 
 	enum NoiseType { Value, ValueFractal, Perlin, PerlinFractal, Simplex, SimplexFractal, Cellular, WhiteNoise, Cubic, CubicFractal };
 	enum Interp { Linear, Hermite, Quintic };
@@ -152,7 +152,7 @@ public:
 	void SetCellularJitter(FN_DECIMAL cellularJitter) { m_cellularJitter = cellularJitter; }
 
 	// Returns the maximum distance a cellular point can move from its grid position
-    FN_DECIMAL GetCellularJitter() const { return m_cellularJitter; }
+	FN_DECIMAL GetCellularJitter() const { return m_cellularJitter; }
 
 	// Sets the maximum warp distance from original location when using GradientPerturb{Fractal}(...)
 	// Default: 1.0


### PR DESCRIPTION
Removes the semicolon at the end of the body of the constructor, for the sake of consistency. This change is purely stylistic. I also made replaced some indentation made of spaces with a tab, again for consistency.