### PR TITLE
Adding support for periodic noise 2d/3d

### DIFF
--- a/FastNoise.cpp
+++ b/FastNoise.cpp
@@ -1,9 +1,3 @@
-// Since simthetiq's code base uses very high warnings, we deactivate them for
-// this non propritary file
-//
-#pragma warning(push, 0)   
-#pragma warning( disable : 4701)
-
 // FastNoise.cpp
 //
 // MIT License
@@ -2454,5 +2448,3 @@ void FastNoise::SingleGradientPerturb(unsigned char offset, FN_DECIMAL warpAmp, 
 	x += Lerp(lx0x, lx1x, ys) * warpAmp;
 	y += Lerp(ly0x, ly1x, ys) * warpAmp;
 }
-
-#pragma warning(pop)

--- a/FastNoise.cpp
+++ b/FastNoise.cpp
@@ -197,13 +197,15 @@ static FN_DECIMAL CubicLerp(FN_DECIMAL a, FN_DECIMAL b, FN_DECIMAL c, FN_DECIMAL
 // i is the index
 // p is the period
 //
-static void indexToPeriodicIndex(int *i, int p)
+static inline void indexToPeriodicIndex(int *i, const int &p)
 {
     if (p > 0)
     {
-        *i = *i % p;
-        if (*i < 0)
-        { *i = p - 1; }
+        int v = *i;
+        v = v % p;
+        if (v < 0)
+        { v = p - 1; }
+        *i = v;
     }
 }
 
@@ -287,7 +289,7 @@ unsigned char FastNoise::Index2D_12(unsigned char offset, int x, int y, int px /
 {
     indexToPeriodicIndex(&x, px);
     indexToPeriodicIndex(&y, py);
-
+    
     return m_perm12[(x & 0x000000ff) + m_perm[(y & 0x000000ff) + offset]];
 }
 unsigned char FastNoise::Index3D_12(unsigned char offset, int x, int y, int z,

--- a/FastNoise.h
+++ b/FastNoise.h
@@ -161,6 +161,12 @@ public:
 	// Returns the maximum warp distance from original location when using GradientPerturb{Fractal}(...)
 	FN_DECIMAL GetGradientPerturbAmp() const { return m_gradientPerturbAmp; }
 
+    // Returns true if the current combination noiseType/FractalType/Cellular...
+    // can be periodic. If so, GetPeriodicNoise(...) will return a periodic
+    // noise, else it returns 0.0f
+    //
+    bool CanBePeriodic() const;
+
 	//2D
 	FN_DECIMAL GetValue(FN_DECIMAL x, FN_DECIMAL y) const;
 	FN_DECIMAL GetValueFractal(FN_DECIMAL x, FN_DECIMAL y) const;
@@ -180,6 +186,7 @@ public:
 	FN_DECIMAL GetCubicFractal(FN_DECIMAL x, FN_DECIMAL y) const;
 
 	FN_DECIMAL GetNoise(FN_DECIMAL x, FN_DECIMAL y) const;
+    FN_DECIMAL GetPeriodicNoise(FN_DECIMAL x, FN_DECIMAL y, int px, int py) const;
 
 	void GradientPerturb(FN_DECIMAL& x, FN_DECIMAL& y) const;
 	void GradientPerturbFractal(FN_DECIMAL& x, FN_DECIMAL& y) const;
@@ -203,6 +210,7 @@ public:
 	FN_DECIMAL GetCubicFractal(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 
 	FN_DECIMAL GetNoise(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
+    FN_DECIMAL GetPeriodicNoise(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px, int py, int pz) const;
 
 	void GradientPerturb(FN_DECIMAL& x, FN_DECIMAL& y, FN_DECIMAL& z) const;
 	void GradientPerturbFractal(FN_DECIMAL& x, FN_DECIMAL& y, FN_DECIMAL& z) const;
@@ -245,10 +253,10 @@ private:
 	FN_DECIMAL SingleValueFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y) const;
 	FN_DECIMAL SingleValue(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y) const;
 
-	FN_DECIMAL SinglePerlinFractalFBM(FN_DECIMAL x, FN_DECIMAL y) const;
-	FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y) const;
-	FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y) const;
-	FN_DECIMAL SinglePerlin(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y) const;
+	FN_DECIMAL SinglePerlinFractalFBM(FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
+	FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
+	FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
+	FN_DECIMAL SinglePerlin(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
 
 	FN_DECIMAL SingleSimplexFractalFBM(FN_DECIMAL x, FN_DECIMAL y) const;
 	FN_DECIMAL SingleSimplexFractalBillow(FN_DECIMAL x, FN_DECIMAL y) const;
@@ -261,8 +269,8 @@ private:
 	FN_DECIMAL SingleCubicFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y) const;
 	FN_DECIMAL SingleCubic(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y) const;
 
-	FN_DECIMAL SingleCellular(FN_DECIMAL x, FN_DECIMAL y) const;
-	FN_DECIMAL SingleCellular2Edge(FN_DECIMAL x, FN_DECIMAL y) const;
+	FN_DECIMAL SingleCellular(FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
+	FN_DECIMAL SingleCellular2Edge(FN_DECIMAL x, FN_DECIMAL y, int px = 0, int py = 0) const;
 
 	void SingleGradientPerturb(unsigned char offset, FN_DECIMAL warpAmp, FN_DECIMAL frequency, FN_DECIMAL& x, FN_DECIMAL& y) const;
 
@@ -272,10 +280,10 @@ private:
 	FN_DECIMAL SingleValueFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 	FN_DECIMAL SingleValue(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 
-	FN_DECIMAL SinglePerlinFractalFBM(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
-	FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
-	FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
-	FN_DECIMAL SinglePerlin(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
+	FN_DECIMAL SinglePerlinFractalFBM(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
+	FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
+	FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
+	FN_DECIMAL SinglePerlin(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
 
 	FN_DECIMAL SingleSimplexFractalFBM(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 	FN_DECIMAL SingleSimplexFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
@@ -287,25 +295,25 @@ private:
 	FN_DECIMAL SingleCubicFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 	FN_DECIMAL SingleCubic(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
 
-	FN_DECIMAL SingleCellular(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
-	FN_DECIMAL SingleCellular2Edge(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z) const;
+	FN_DECIMAL SingleCellular(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
+	FN_DECIMAL SingleCellular2Edge(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, int px = 0, int py = 0, int pz = 0) const;
 
 	void SingleGradientPerturb(unsigned char offset, FN_DECIMAL warpAmp, FN_DECIMAL frequency, FN_DECIMAL& x, FN_DECIMAL& y, FN_DECIMAL& z) const;
 
 	//4D
 	FN_DECIMAL SingleSimplex(unsigned char offset, FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, FN_DECIMAL w) const;
 
-	inline unsigned char Index2D_12(unsigned char offset, int x, int y) const;
-	inline unsigned char Index3D_12(unsigned char offset, int x, int y, int z) const;
+	inline unsigned char Index2D_12(unsigned char offset, int x, int y, int px = 0, int py = 0) const;
+	inline unsigned char Index3D_12(unsigned char offset, int x, int y, int z, int px = 0, int py = 0, int pz = 0) const;
 	inline unsigned char Index4D_32(unsigned char offset, int x, int y, int z, int w) const;
-	inline unsigned char Index2D_256(unsigned char offset, int x, int y) const;
-	inline unsigned char Index3D_256(unsigned char offset, int x, int y, int z) const;
+	inline unsigned char Index2D_256(unsigned char offset, int x, int y, int px = 0, int py = 0) const;
+	inline unsigned char Index3D_256(unsigned char offset, int x, int y, int z, int px = 0, int py = 0, int pz = 0) const;
 	inline unsigned char Index4D_256(unsigned char offset, int x, int y, int z, int w) const;
 
 	inline FN_DECIMAL ValCoord2DFast(unsigned char offset, int x, int y) const;
 	inline FN_DECIMAL ValCoord3DFast(unsigned char offset, int x, int y, int z) const;
-	inline FN_DECIMAL GradCoord2D(unsigned char offset, int x, int y, FN_DECIMAL xd, FN_DECIMAL yd) const;
-	inline FN_DECIMAL GradCoord3D(unsigned char offset, int x, int y, int z, FN_DECIMAL xd, FN_DECIMAL yd, FN_DECIMAL zd) const;
+	inline FN_DECIMAL GradCoord2D(unsigned char offset, int x, int y, FN_DECIMAL xd, FN_DECIMAL yd, int px = 0, int py = 0) const;
+	inline FN_DECIMAL GradCoord3D(unsigned char offset, int x, int y, int z, FN_DECIMAL xd, FN_DECIMAL yd, FN_DECIMAL zd, int px = 0, int py = 0, int pz = 0) const;
 	inline FN_DECIMAL GradCoord4D(unsigned char offset, int x, int y, int z, int w, FN_DECIMAL xd, FN_DECIMAL yd, FN_DECIMAL zd, FN_DECIMAL wd) const;
 };
 #endif


### PR DESCRIPTION
- Not all noise can be periodic, this commit adds support to Perlin,
  PerlinFractal and Cellular. In theory Simplex and SimplexFractal should
  be triavial, but it did not work...
- added GetPeriodicNoise function to sample periodic noise.
- Perlin, PerlinFractal and Cellular (2D/3D) are supported by GetPeriodicNoise()